### PR TITLE
Update package. Mini fix for mirror

### DIFF
--- a/voting/processor/mirror.js
+++ b/voting/processor/mirror.js
@@ -201,6 +201,14 @@ async function main() {
         // use input numbers
     }
 
+    let nextElectionBlock = await orbs.getNextElectionsBlockNumber();
+    if (endBlock > nextElectionBlock) { // don't try to mirror events past the election - less errors when mirror runs just before election
+        if (verbose) {
+            console.log('\x1b[34m%s\x1b[0m', `Adjusting end block to not be after current election (end block changed from ${endBlock} to ${nextElectionBlock})`);
+        }
+        endBlock = nextElectionBlock;
+    }
+
     console.log('\x1b[34m%s\x1b[0m', `Going to look for events between blocks ${startBlock}-${endBlock}`);
     await iterateOverEvents(orbs, startBlock, endBlock, paceEthereum);
     if (verbose) {

--- a/voting/processor/package.json
+++ b/voting/processor/package.json
@@ -9,9 +9,9 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@slack/web-api": "5.0.1",
-    "lodash": "^4.17.13",
-    "orbs-client-sdk": "0.0.6",
+    "@slack/web-api": "^5.8.0",
+    "lodash": "^4.17.15",
+    "orbs-client-sdk": "^2.4.0",
     "typedarray-to-buffer": "3.1.5",
     "web3": "1.0.0-beta.55",
     "yaeti": "0.0.6"

--- a/voting/processor/src/orbs.js
+++ b/voting/processor/src/orbs.js
@@ -22,7 +22,7 @@ class Orbs {
 
         this.name = name;
         this.signer = OrbsClientSdk.createAccount();
-        this.client = new OrbsClientSdk.Client(url, vChainId, OrbsClientSdk.NetworkType.NETWORK_TYPE_TEST_NET);
+        this.client = new OrbsClientSdk.Client(url, vChainId, OrbsClientSdk.NetworkType.NETWORK_TYPE_TEST_NET, new OrbsClientSdk.LocalSigner(this.signer));
         this.helpers = OrbsClientSdk;
     }
 
@@ -58,6 +58,10 @@ class Orbs {
         return Number(await this.queryResult("getNumberOfElections"));
     }
 
+    async getNextElectionsBlockNumber() {
+        return Number(await this.queryResult("getCurrentElectionBlockNumber"));
+    }
+
     async getTotalStake() {
         return Number(await this.queryResult("getTotalStake"));
     }
@@ -86,13 +90,13 @@ class Orbs {
         }
     }
 
-    transact(methodName, ...args) {
-        const [t] = this.client.createTransaction(this.signer.publicKey, this.signer.privateKey, this.name, methodName, args);
+    async transact(methodName, ...args) {
+        const [t] = await this.client.createTransaction(this.name, methodName, args);
         return this.client.sendTransaction(t);
     }
 
-    query(methodName, ...args) {
-        const q = this.client.createQuery(this.signer.publicKey, this.name, methodName, args);
+    async query(methodName, ...args) {
+        const q = await this.client.createQuery(this.name, methodName, args);
         return this.client.sendQuery(q);
     }
 


### PR DESCRIPTION
update orbs-client-sdk version. Limit mirror to not try sending mirrors when their block happened after election (this removes some visual errors as there usually are 2-5 mirror runs before process starts).

